### PR TITLE
Ruby 3.x support

### DIFF
--- a/lib/jsom/pagination/links.rb
+++ b/lib/jsom/pagination/links.rb
@@ -39,7 +39,7 @@ module JSOM
       end
 
       def parse_url(url)
-        uri = URI.parse(URI.unescape(url))
+        uri = URI.parse(CGI.unescape(url))
         url_params = Rack::Utils.parse_nested_query(
           uri.query
         ).delete_if { |key, _value| key == 'page' }


### PR DESCRIPTION
`URI.unescape` is obsolete in ruby `3.x`:

> This method is obsolete and should not be used. Instead, use CGI.escape, URI.encode_www_form or URI.encode_www_form_component depending on your specific use case.

This PR fixes this :)